### PR TITLE
Added mapping in Kml.NameSpaceBeautyfier to map kml to the default namespace

### DIFF
--- a/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
+++ b/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
@@ -958,6 +958,9 @@ public class Kml implements Cloneable
          */
         @Override
         public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+            if (namespaceUri.matches("http://www.opengis.net/kml/.*?")) {
+            	return "";
+            }
             if (namespaceUri.matches("http://www.w3.org/\\d{4}/Atom")) {
                 return "atom";
             }


### PR DESCRIPTION
This is a quick "fix" for Issue #5. It makes http://www.opengis.net/kml/2.2 the default namespace so that the kml doesn't use ns2: (or ns:3).