### PR TITLE
Allow library consumers to decorate the JAXB marshaller in KML subclasses

### DIFF
--- a/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
+++ b/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
@@ -621,11 +621,28 @@ public class Kml implements Cloneable
         throws JAXBException
     {
         if (marshaller == null) {
-            marshaller = getJaxbContext().createMarshaller();
+            JAXBContext context = getJaxbContext();
+            marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            //marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new Kml.NameSpaceBeautyfier());
+            decorateMarshaller(context, marshaller);
         }
         return marshaller;
+    }
+
+    /**
+     * Allow 3rd parties to decorate the marshaller to add additional functionality.
+     *
+     * @param context Context that created the marshaller.
+     * @param marshaller The marshaller to decorate.
+     */
+    protected void decorateMarshaller(JAXBContext context, Marshaller marshaller)
+    {
+        // no-op by default
+        //
+        // Child classes can use this to add additional properties to the marshaller such as NamespacePrefixMapper implementations
+        //
+        // Example:
+        //    marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new Kml.NameSpaceBeautyfier());
     }
 
     /**


### PR DESCRIPTION
This will allow library consumers to use JAXB implementation specific _(whichever implementation is up to them)_ features such as vendor specific `NamespacePrefixMapper`s.

Without this change, library consumers must use Reflection to acheive the same effect which is not desirable:
```java
try
{
    // Dummy marshal call to initialize the marshaller
    var initializerMethod = Kml.class.getDeclaredMethod("createMarshaller");
    initializerMethod.setAccessible(true);
    initializerMethod.invoke(kml);
    // Register our prefix mapper to get rid of "kml:" prefixes on elements.
    var marshallerField = Kml.class.getDeclaredField("marshaller");
    marshallerField.setAccessible(true);
    Marshaller marshaller = (Marshaller) marshallerField.get(kml);
    marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new KmlNamespaceFixer());
} catch (Throwable t)
{
    logger.error("Failed to register namespace fixer for track KML export", t);
}
```