### PR TITLE
Allow library consumers to register alternative KML 2.X complaint specification URIs

### DIFF
--- a/src/main/java/de/micromata/opengis/kml/v_2_2_0/NamespaceFilterHandler.java
+++ b/src/main/java/de/micromata/opengis/kml/v_2_2_0/NamespaceFilterHandler.java
@@ -6,15 +6,44 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 
-final class NamespaceFilterHandler
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class NamespaceFilterHandler
     implements ContentHandler
 {
-
     private final static String KML_20 = "http://earth.google.com/kml/2.0";
     private final static String KML_21 = "http://earth.google.com/kml/2.1";
     private final static String E_KML_22 = "http://earth.google.com/kml/2.2";
     private final static String KML_22 = "http://www.opengis.net/kml/2.2";
-    private ContentHandler contentHandler;
+    private final static List<String> KML_2_SPECS = new ArrayList<>();
+
+    static {
+        KML_2_SPECS.add(KML_20);
+        KML_2_SPECS.add(KML_21);
+        KML_2_SPECS.add(E_KML_22);
+        KML_2_SPECS.add(KML_22);
+    }
+
+    /**
+     * Adds a URI of a known KML 2.X compatible specification.
+     *
+     * @param uri URI to a compatible KML 2.X implementation.
+     */
+    public static void addKml2SpecUri(String uri) {
+        KML_2_SPECS.add(uri);
+    }
+
+    /**
+     * @return List of known/supported KML 2.X specification URIs.
+     */
+    public List<String> getKml2SpecUris() {
+        return Collections.unmodifiableList(KML_2_SPECS);
+    }
+
+    private final ContentHandler contentHandler;
 
     public NamespaceFilterHandler(ContentHandler contentHandler) {
         this.contentHandler = contentHandler;
@@ -23,9 +52,11 @@ final class NamespaceFilterHandler
     public void startElement(String uri, String localName, String qName, Attributes atts)
         throws SAXException
     {
-        if (uri.equals(KML_20)||uri.equals(KML_21)||uri.equals(E_KML_22)) {
+        if (KML_2_SPECS.contains(uri))
+        {
             contentHandler.startElement(KML_22, localName, qName, atts);
-        } else {
+        } else
+        {
             contentHandler.startElement(uri, localName, qName, atts);
         }
     }

--- a/src/test/java/de/micromata/jak/AlternativeKmlSpecTest.java
+++ b/src/test/java/de/micromata/jak/AlternativeKmlSpecTest.java
@@ -1,0 +1,33 @@
+package de.micromata.jak;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.NamespaceFilterHandler;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link NamespaceFilterHandler} allows registration of 3rd party KML specifications.
+ * <br>
+ * This can be used by 3rd parties that have KML 2.X complaint specifications with minor tweaks
+ * not related to data model structure.
+ */
+public class AlternativeKmlSpecTest {
+    @Test
+    public void test() {
+        String impl = "http://example.com/kml/2.X";
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<kml xmlns=\"" + impl + "\">\n"
+                + "    <Document>\n"
+                + "        <name>NDBC BuoyCAM Stations</name>\n"
+                + "        <open>1</open>\n"
+                + "    </Document>\n"
+                + "</kml>\n";
+        try {
+            Assert.assertNull("Expected unknown KML spec to fail initially", Kml.unmarshal(content));
+            NamespaceFilterHandler.addKml2SpecUri(impl);
+            Assert.assertNotNull(Kml.unmarshal(content));
+        } catch (Exception ex) {
+           Assert.fail(ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This will allow 3rd party library consumers to support compliant KML 2.X specifications not recognized by the built-in list. Should address issues like #51