### PR TITLE
Fix Coordinate converter regression handling 2 coordinate items as 3

### DIFF
--- a/src/main/java/de/micromata/opengis/kml/v_2_2_0/CoordinatesConverter.java
+++ b/src/main/java/de/micromata/opengis/kml/v_2_2_0/CoordinatesConverter.java
@@ -11,7 +11,7 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 public final class CoordinatesConverter
     extends XmlAdapter<String, List<Coordinate>>
 {
-    private static final Pattern COORDINATE_GROUP = Pattern.compile("(?<=,|\\s|^)(\\S+?,\\S+?,\\S+?)");
+    private static final Pattern COORDINATE_GROUP = Pattern.compile("(?<=,|\\s|^)([-.\\d]+,[-.\\d]+(?:,[-.\\d]+)?)");
 
     @Override
     public String marshal(final List<Coordinate> dt)


### PR DESCRIPTION
It looks like when I ran the test suite from IntelliJ not all the tests executed, which is why I didn't notice this pattern didn't support 2-coordinate entries.